### PR TITLE
Added .row div wrapper as per bootstrap docs

### DIFF
--- a/src/templates/questionEditors/questioneditortab-general.html
+++ b/src/templates/questionEditors/questioneditortab-general.html
@@ -1,11 +1,13 @@
 ﻿<script type="text/html" id="questioneditortab-general">
-    <div class="col-sm-12">
-        <!-- ko foreach: properties.rows -->
-        <div class="form-group">
-            <!-- ko foreach: properties -->
-                <!-- ko template: { name: 'propertyeditor', data: objectProperty.editor } --><!-- /ko -->
+    <div class="row">
+        <div class="col-sm-12">
+            <!-- ko foreach: properties.rows -->
+            <div class="form-group">
+                <!-- ko foreach: properties -->
+                    <!-- ko template: { name: 'propertyeditor', data: objectProperty.editor } --><!-- /ko -->
+                <!-- /ko  -->
+            </div>
             <!-- /ko  -->
         </div>
-        <!-- /ko  -->
     </div>
 </script>


### PR DESCRIPTION
Fixes general tab content (the modal footer border was sitting at the top basically, so looked broken)