### PR TITLE
Ensure the onPropertyValidationCustomError event is not skipped for required properties

### DIFF
--- a/src/propertyEditors/propertyEditorBase.ts
+++ b/src/propertyEditors/propertyEditorBase.ts
@@ -151,10 +151,10 @@ export class SurveyPropertyEditorBase implements Survey.ILocalizableOwner {
   protected checkForErrors(): boolean {
     if (this.isRequired) {
       var er = this.isValueEmpty(this.koValue());
-      this.koErrorText(
-        er ? editorLocalization.getString("pe.propertyIsEmpty") : ""
-      );
-      return er;
+      if (er) {
+        this.koErrorText(editorLocalization.getString("pe.propertyIsEmpty"));
+        return er;
+      }
     }
     if (
       this.property &&

--- a/tests/questionEditorsTests.ts
+++ b/tests/questionEditorsTests.ts
@@ -359,6 +359,36 @@ QUnit.test("Question editor: custom errors", function(assert) {
   assert.equal(properties.hasError(), false, "There is no error now");
 });
 
+
+QUnit.test("Question editor: custom errors on required field", function(assert) {
+  var question = new Survey.QuestionText("invalidName");
+  var editor = new SurveyEditor();
+  editor.onPropertyValidationCustomError.add(function(editor, options) {
+    if (options.propertyName != "name") return;
+    if (options.value == 'invalidName') {
+      options.error = "I'm sorry you can not use that name";
+      return;
+    }
+  });
+  var properties = new SurveyQuestionEditorGeneralProperties(
+    question,
+    ["name"],
+    null,
+    editor
+  );
+  assert.equal(
+    properties.hasError(),
+    true,
+    "error message should be triggered"
+  );
+  var nameEditor = properties.rows[0].properties[0].editor;
+  nameEditor.koValue("validName");
+  assert.equal(properties.hasError(), false, "There is no error now");
+
+  nameEditor.koValue("");
+  assert.equal(properties.hasError(), true, "Validator still checks that property is not empty");
+
+});
 QUnit.test("Question editor: on property value changing", function(assert) {
   Survey.JsonObject.metaData.addProperty("question", { name: "targetEntity" });
   Survey.JsonObject.metaData.addProperty("question", {


### PR DESCRIPTION
I was trying to add a validator to prevent users from creating two questions with the same name (similar to #116), but found that the onPropertyValidationCustomError callback was skipped entirely for the name property. I managed to trace through and found that a method was returning early based on the isRequired property.

Thank you as always for your efforts on an amazing library/set of tools!