### PR TITLE
Issue #400 Wiggling text input resolved using canvas measure text.

### DIFF
--- a/src/adorners/title-editor.ts
+++ b/src/adorners/title-editor.ts
@@ -6,8 +6,28 @@ import "./title-editor.scss";
 import * as Survey from "survey-knockout";
 var templateHtml = require("html-loader?interpolate!val-loader!./title-editor.html");
 
+const FRIENDLY_PADDING = 36;
 function resizeInput(target) {
-  target.size = target.value.length || 5;
+  let computedStyle = window.getComputedStyle(target);
+  target.style.width = (getTextWidth(target.value, computedStyle.font) + FRIENDLY_PADDING) + 'px';
+}
+
+/**
+ * Uses canvas.measureText to compute and return the width of the given text of given font in pixels.
+ * 
+ * @param {String} text The text to be rendered.
+ * @param {String} font The css font descriptor that text is to be rendered with (e.g. "bold 14px verdana").
+ * 
+ * @see https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
+ */
+let cachedCanvas;
+function getTextWidth(text, font) {
+  // re-use canvas object for better performance
+  var canvas = cachedCanvas || (cachedCanvas = document.createElement("canvas"));
+  var context = canvas.getContext("2d");
+  context.font = font;
+  var metrics = context.measureText(text);
+  return metrics.width;
 }
 
 export class TitleInplaceEditor {


### PR DESCRIPTION
https://github.com/surveyjs/editor/issues/400

Leverages a canvas' context's `measureText` method to calculate the appropriate length of a text input, rather than setting the inputs size which is not effective on non-monospaced fonts.